### PR TITLE
20241017 10:12 박가빈 아이디/비번찾기/신고관리 일부 수정, 신고하기/신고상세 모달 크기 축소, reply(댓글기…

### DIFF
--- a/publishing/css/admin/admReport.css
+++ b/publishing/css/admin/admReport.css
@@ -5,6 +5,7 @@
 
 main {
   margin: 0px 300px;
+  min-width: 1300px;
 }
 
 h1 {
@@ -102,6 +103,9 @@ td {
   width:110px;
   margin:0 40px 0 20px;
 }
+#sanction-reason{
+  margin-left:auto;
+}
 
 .modal-container{
   display: none;
@@ -116,7 +120,9 @@ td {
 
 .modal-container>*{
   display:none;
-  width:480px;
+  width:20%;
+  min-width:400px;
+  height:500px;
   border: 1px solid #d9d9d9;
   background-color: white;
 }
@@ -127,7 +133,7 @@ td {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  height:50px;
+  height:10%;
   font-size:36px;
   font-weight: 600;
 }
@@ -149,7 +155,7 @@ td {
 
 #report-detail-text{
   margin-top: 30px;
-  height:150px;
+  height:100px;
   resize: none;
 }
 

--- a/publishing/css/login/login.css
+++ b/publishing/css/login/login.css
@@ -55,11 +55,12 @@ input {
   width: 280px;
   height: 30px;
   padding: 0px 10px;
-  margin: 10px 0;
   border: 1px solid #D9D9D9;
   border-radius: 10px;
 }
-
+input[type="text"]{
+  margin-bottom: 20px;
+}
 #invalid-login{
   width: 100%;
   max-width: 302px;

--- a/publishing/css/login/lostIdSelectCert.css
+++ b/publishing/css/login/lostIdSelectCert.css
@@ -60,8 +60,8 @@ h2 {
   display: flex;
   align-items: center;
   width:400px;
-  height:37px;
-  border-bottom: 3px solid #FEF2F2;
+  height:28px;
+  border-bottom: 2px solid #845AC6;
   padding : 10px 0 10px 0;
 }
 

--- a/publishing/css/login/lostIdShow.css
+++ b/publishing/css/login/lostIdShow.css
@@ -53,9 +53,9 @@ h2 {
 
 .email span{
   display: inline-block;
-  height:27px;
+  height:28px;
   font-size: 20px;
-  border-bottom: 3px solid #FEF2F2;
+  border-bottom: 2px solid #845AC6;
   margin-bottom: 70px;
 }
 #button-container{

--- a/publishing/css/login/lostPswdEmailCert.css
+++ b/publishing/css/login/lostPswdEmailCert.css
@@ -56,8 +56,8 @@ h2 {
   display: flex;
   align-items: center;
   width:400px;
-  height:37px;
-  border-bottom: 3px solid #FEF2F2;
+  height:28px;
+  border-bottom: 2px solid #845AC6;
   padding : 10px 0 10px 0;
 }
 .input-email form, .input-cert form{

--- a/publishing/css/login/lostPswdReset.css
+++ b/publishing/css/login/lostPswdReset.css
@@ -54,9 +54,9 @@ h2 {
 .input-pswd{
   margin : 10px auto;
   width:400px;
-  height:27px;
+  height:28px;
   border : 0;
-  border-bottom: 3px solid #FEF2F2;
+  border-bottom: 2px solid #845AC6;
   padding : 10px 0 10px 0;
 }
 

--- a/publishing/css/login/lostPswdSelectCert.css
+++ b/publishing/css/login/lostPswdSelectCert.css
@@ -60,8 +60,8 @@ h2 {
   display: flex;
   align-items: center;
   width:400px;
-  height:37px;
-  border-bottom: 3px solid #FEF2F2;
+  height:28px;
+  border-bottom: 2px solid #845AC6;
   padding : 10px 0 10px 0;
 }
 

--- a/publishing/css/report/reportSend.css
+++ b/publishing/css/report/reportSend.css
@@ -18,8 +18,11 @@
     background-color: rgba(0,0,0,0.1);
 }
 #report-modal{
-    width:480px;
-    height:600px;
+    width:20%;
+    min-width:400px;
+    height:40%;
+    min-height: 400px;;
+    max-height: 450px;
     position:absolute;
     top: 50%;
     left: 50%;
@@ -33,7 +36,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height:50px;
+    height:10%;
     font-size:36px;
     font-weight: 600;
 }
@@ -42,6 +45,7 @@
 }
 #report-modal-mid{
     width:75%;
+    height:40%;
     margin:20px auto;
     display: flex;
     flex-direction: column;
@@ -53,7 +57,7 @@
 
 #report-detail-text{
     margin-top: 30px;
-    height:150px;
+    height:100px;
     resize: none;
 }
 

--- a/publishing/html/report/reportSend.html
+++ b/publishing/html/report/reportSend.html
@@ -16,19 +16,19 @@
       <form action="">
         <section id="report-modal-mid">
           <div>
-            <input type="radio" name="report-type">&nbsp;욕설 또는 타인 비방
+            신고 사유 선택
           </div>
           <div>
-            <input type="radio" name="report-type">&nbsp;희롱, 괴롭힘 또는 노골적인 폭력
-          </div>
-          <div>
-            <input type="radio" name="report-type">&nbsp;저작권 위반
-          </div>
-          <div>
-            <input type="radio" name="report-type">&nbsp;기타
-          </div>
-          <div>
-            <input type="radio" name="report-type">&nbsp;정보 오류
+            <label for="">
+              <select name="" id="year">
+                <option value="N" disabled selected>신고 사유를 선택해주세요.</option>
+                <option value="1">욕설 또는 타인 비방</option>
+                <option value="2">희롱, 괴롭힘 또는 노골적인 폭력</option>
+                <option value="3">저작권 위반</option>
+                <option value="4">기타</option>
+                <option value="5">정보 오류</option>
+              </select>
+            </label>
           </div>
           <textarea id="report-detail-text" placeholder="자세한 상황을 설명해주세요."></textarea>
         </section>

--- a/publishing/js/login/reply.js
+++ b/publishing/js/login/reply.js
@@ -31,7 +31,7 @@ $("#submit-reply").click(function(){
 // 좋아요 누르면 등록 + 숫자 하나 올라감
 picked = "../../img/journal/footprint_pick.png"
 Npicked = "../../img/journal/footprint.png"
-$(".likes img[alt='좋아요']").click(function(){
+$("#reply").on('click', ".likes img[alt='좋아요']",function(){
   //좋아요가 여러개이기 때문에, $(this)로 클릭당한 자신을 기준으로 해야 됨
   now = $(this).attr('src');
   cnt = Number($(this).siblings('span').text())
@@ -43,7 +43,22 @@ $(".likes img[alt='좋아요']").click(function(){
     $(this).siblings('span').text(String(cnt+1));
   }
   return;
+});
+
+//삭제 누르면 삭제되고
+$("#reply").on('click', ".reply-buttons>img[alt='삭제']", function(){
+  if(confirm("정말 삭제하시겠습니까?") == false){
+    return;
+  }
+    //db처리
+  $(this).closest(".written").remove();
+  alert("삭제가 완료되었습니다.")
 })
+
+//여기서 $("#reply").on('click', 선택자, function(){}) 이렇게 한 이유는,
+//js에서 새로 작성한 html에는 이벤트가 직접적으로는 등록이 안됨.
+//그래서 원래 html에 있던 요소를 매개로 등록해줘야함.
+//#reply의 자손 중에 선택자에 해당하는 모든 요소에게 해당 이벤트를 부여한다 - 이런 뜻임.
 
 // 더보기 누르면 스크롤 형태로 다 보여줌
 $("#reply-more").click(function(){
@@ -52,18 +67,7 @@ $("#reply-more").click(function(){
   $("#reply-more").css('display','none');
 })
 
-  //삭제 누르면 삭제되고
-$(".reply-buttons>img[alt='삭제']").click(function(){
-  if(confirm("정말 삭제하시겠습니까?") == false){
-    return;
-  }
-    //db처리
-  $(this).closest(".written").remove();
-  alert("삭제가 완료되었습니다.")
-})
-//근데 추가한 댓글을 바로 삭제하는 법을 모르겠네;;
-
-
+//추가한 댓글 바로 삭제 서
 
 //신고하기
 //이거는 같은 신고하기 모달을 쓰니까 같이 연결하는걸로


### PR DESCRIPTION
1) 아이디/비번찾기 과정 중 입력칸 밑의 분홍 선 -> 보라색 선으로 모두 변경

2) 신고관리 제재하기 바 최소 사이즈 고정 -> 깨짐 방지

3) 신고하기 모달 / 신고 상세 모달 크기 가능한 축소
3-1) 신고하기 모달 신고 분류 입력방식 radio -> select로 변경

4) reply.html/css/js 기능 완전 구현
새벽에 올릴 때 못했던 게
1) 신고하기 - 페이지에 신고하기 모달을 적용한 뒤, img에 각자 page의 class를 적용 - 각자가 할 일
2) 추가한 댓글은 기능 구현 불가 - 해결함
